### PR TITLE
Update windows.md

### DIFF
--- a/computer-setup/windows.md
+++ b/computer-setup/windows.md
@@ -181,3 +181,5 @@ It's helpful to have the [Slack App](https://slack.com/downloads/windows).
 Click the link below and follow the instructions:
 
 [Install the IBM Cloud CLI](./ibmcloud.md)
+
+On WSL2, use the Linux command line install: `curl -fsSL https://clis.cloud.ibm.com/install/linux | sh`


### PR DESCRIPTION
In case you want to show the command line. The docs do not specify how to install for WSL2. And it was easy to use the wrong Linux command line and to dive into a need to set up systemd (which is not included so far with WSL), which does not seem to be required for IBM Cloud CLI. The CLI Docs also mention Windows Pro, which installs in PowerShell and not in WSL.